### PR TITLE
Usage with CDN instructions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -25,6 +25,24 @@ Or just include files within the asset pipeline:
 
   //= require js_exception_notifier
 
+=== Usage when serving JS from CDN
+
+As stated {here}[https://errorception.com/docs/cors] and {here}[https://developer.mozilla.org/en/docs/Web/HTML/Element/script#attr-crossorigin]
+  Due to a potential security issue, browsers traditionally don't provide access to error data if the script violates the 
+  same-origin policy. Instead, browsers just report a meaningless Script error on line 0, with no additional data.
+
+If you are serving your javascript assets through a CDN (Cloudfront for eg), you need to 
+* have HTTP CORS headers (not covered here)
+* load your JS with a +crossorigin+ tag to enable meaningful error reporting through +window.onerror+
+
+The latter is done with
+
+  javascript_include_tag "js_exception_notifier.js", crossorigin: 'anonymous' 
+
+Or if js_exception_notifier is added to the asset pipeline
+
+  javascript_include_tag "application", crossorigin: 'anonymous'
+
 == JsExceptionNotifier comes with a dummy app:
 
   bundle

--- a/README.rdoc
+++ b/README.rdoc
@@ -27,13 +27,11 @@ Or just include files within the asset pipeline:
 
 === Usage when serving JS from CDN
 
-As stated {here}[https://errorception.com/docs/cors] and {here}[https://developer.mozilla.org/en/docs/Web/HTML/Element/script#attr-crossorigin]
-  Due to a potential security issue, browsers traditionally don't provide access to error data if the script violates the 
-  same-origin policy. Instead, browsers just report a meaningless Script error on line 0, with no additional data.
+Due to a potential security issue, browsers traditionally don't provide access to error data if the script violates the same-origin policy. Instead, browsers just report a meaningless Script error on line 0, with no additional data.
 
 If you are serving your javascript assets through a CDN (Cloudfront for eg), you need to 
 * have HTTP CORS headers (not covered here)
-* load your JS with a +crossorigin+ tag to enable meaningful error reporting through +window.onerror+
+* load your JS with a +crossorigin+ tag to enable error reporting
 
 The latter is done with
 


### PR DESCRIPTION
Hi and thanks you for this gem

After moving my assets to a CDN distribution, I realized that the error reporting had become sporadic. I found out that despite having HTTP CORS headers in place, browsers were giving minimal to zero information about the error to scripts loaded in different origins. 

TraceKit was informed, but js-exception-notifier layer was filtering those away for lack of trace and context. 

I suggest adding instructions on the Readme with this pull request.

First commit has external links to not-free alternatives, Second commit simplifies the readme to the simplest instructions. I prefer to let you choose since it's my first github contribution

Best