### PR TITLE
Rename *_filter callbacks to *_action

### DIFF
--- a/app/controllers/js_exception_notifier_controller.rb
+++ b/app/controllers/js_exception_notifier_controller.rb
@@ -2,8 +2,8 @@ class JsExceptionNotifierController < ApplicationController
   THROTTLE_MAX_RATE = 10.0          # Max 10 error reports from single user
   THROTTLE_DURATION = 240.0 * 60.0   # per 240*60 sec = 4 hour. Keep these values as floats.
 
-  before_filter :enforce_rate_limit
-  # skip_before_filter :verify_authenticity_token
+  before_action :enforce_rate_limit
+  # skip_before_action :verify_authenticity_token
 
   class JSException < StandardError
     attr_reader :message


### PR DESCRIPTION
This updates *_filter callbacks to *_action since the "filter" variants were deprecated in Rails 4.x and removed from Rails 5.x.