### PR TITLE
ErrorReport could be nil

### DIFF
--- a/app/controllers/js_exception_notifier_controller.rb
+++ b/app/controllers/js_exception_notifier_controller.rb
@@ -20,7 +20,8 @@ class JsExceptionNotifierController < ApplicationController
       data[:session] = session.keys.collect{ |k| {:k=> k, :v=> session[k]}.inspect } if session.loaded?
       data[:errorReport] = params['errorReport']
 
-      ExceptionNotifier.notify_exception(JSException.new(params['errorReport']['message'].to_s), :data=> data)
+      error_message = params['errorReport'] ? params['errorReport']['message'].to_s : "no error report given"
+      ExceptionNotifier.notify_exception(JSException.new(error_message), :data=> data)
       render json: {}, status: 200
     elsif Rails.env.test?
       render json: { status: 'OK', text: params['errorReport'].to_s }, status: 200


### PR DESCRIPTION
The following error occurs in this controller.

A NoMethodError occurred in js_exception_notifier#javascript_error:

  undefined method `[]' for nil:NilClass

-------------------------------
Request:
-------------------------------

  * URL        : https://www.example.com/js_exception_notifier
  * HTTP Method: POST

This error could occur if a post request is send without an param['errorReport']

How could just a request be made is not yet clear to me, but they are happening like 10-20 a day with real users and not with search bots.
As a safety we should check if there is param['errorReport'] send to this url and if not, report for this